### PR TITLE
Include otus to vendorsetup.sh

### DIFF
--- a/vendorsetup.sh
+++ b/vendorsetup.sh
@@ -1,2 +1,3 @@
+add_lunch_combo maxi_otus-userdebug
 add_lunch_combo maxi_jagnm-userdebug
 add_lunch_combo maxi_lt02wifi-userdebug


### PR DESCRIPTION
Motorola Moto E 2015 3G a.k.a otus it's now officially supported by MaxiCM, for that reason i added the device to vendorsetup.sh
